### PR TITLE
Allow an offset when calculating an EMA

### DIFF
--- a/cached_indicator.go
+++ b/cached_indicator.go
@@ -44,3 +44,19 @@ func returnIfCached(indicator cachedIndicator, index int, firstValueFallback fun
 
 	return nil
 }
+
+func returnIfCachedWithOffset(indicator cachedIndicator, index int, offset int, firstValueFallback func(int) big.Decimal) *big.Decimal {
+	if index >= len(indicator.cache()) {
+		expandResultCache(indicator, index+1)
+	} else if index < indicator.windowSize()+offset-1 {
+		return &big.ZERO
+	} else if val := indicator.cache()[index]; val != nil {
+		return val
+	} else if index == indicator.windowSize()-1 {
+		value := firstValueFallback(index)
+		cacheResult(indicator, index, value)
+		return &value
+	}
+
+	return nil
+}

--- a/indicator_exponential_moving_average_with_offset.go
+++ b/indicator_exponential_moving_average_with_offset.go
@@ -1,0 +1,47 @@
+package techan
+
+import "github.com/sdcoffey/big"
+
+type emaIndicatorWithOffset struct {
+	indicator   Indicator
+	window      int
+	offset      int
+	alpha       big.Decimal
+	resultCache resultCache
+}
+
+// NewEMAIndicator returns a derivative indicator which returns the average of the current and preceding values in
+// the given windowSize, with values closer to current index given more weight. A more in-depth explanation can be found here:
+// http://www.investopedia.com/terms/e/ema.asp
+func NewEMAIndicatorWithOffset(indicator Indicator, window int, offset int) Indicator {
+	return &emaIndicatorWithOffset{
+		indicator:   indicator,
+		window:      window,
+		offset:      offset,
+		alpha:       big.ONE.Frac(2).Div(big.NewFromInt(window + 1)),
+		resultCache: make([]*big.Decimal, 1000),
+	}
+}
+
+func (ema *emaIndicatorWithOffset) Calculate(index int) big.Decimal {
+	if cachedValue := returnIfCachedWithOffset(ema, index, ema.offset, func(i int) big.Decimal {
+		return NewSimpleMovingAverage(ema.indicator, ema.window).Calculate(i)
+	}); cachedValue != nil {
+		return *cachedValue
+	}
+
+	todayVal := ema.indicator.Calculate(index).Mul(ema.alpha)
+	result := todayVal.Add(ema.Calculate(index - 1).Mul(big.ONE.Sub(ema.alpha)))
+
+	cacheResult(ema, index, result)
+
+	return result
+}
+
+func (ema emaIndicatorWithOffset) cache() resultCache { return ema.resultCache }
+
+func (ema *emaIndicatorWithOffset) setCache(newCache resultCache) {
+	ema.resultCache = newCache
+}
+
+func (ema emaIndicatorWithOffset) windowSize() int { return ema.window }

--- a/indicator_macd.go
+++ b/indicator_macd.go
@@ -10,6 +10,6 @@ func NewMACDIndicator(baseIndicator Indicator, shortwindow, longwindow int) Indi
 // NewMACDHistogramIndicator returns a derivative Indicator based on the MACDIndicator, the result of which is
 // the macd indicator minus it's signalLinewindow EMA. A more in-depth explanation can be found here:
 // http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:macd-histogram
-func NewMACDHistogramIndicator(macdIdicator Indicator, signalLinewindow int) Indicator {
-	return NewDifferenceIndicator(macdIdicator, NewEMAIndicator(macdIdicator, signalLinewindow))
+func NewMACDHistogramIndicator(macdIdicator Indicator, signalLinewindow int, macdLongWindow int) Indicator {
+	return NewDifferenceIndicator(macdIdicator, NewEMAIndicatorWithOffset(macdIdicator, signalLinewindow, macdLongWindow))
 }

--- a/indicator_macd_test.go
+++ b/indicator_macd_test.go
@@ -18,7 +18,7 @@ func TestNewMACDHistogramIndicator(t *testing.T) {
 	series := randomTimeSeries(100)
 
 	macd := NewMACDIndicator(NewClosePriceIndicator(series), 12, 26)
-	macdHistogram := NewMACDHistogramIndicator(macd, 9)
+	macdHistogram := NewMACDHistogramIndicator(macd, 9, 26)
 
 	assert.NotNil(t, macdHistogram)
 }


### PR DESCRIPTION
When creating a MACD signal line, using the 9 period EMA results in a long period of time (~60 or so candles) before the macdhistogram accurately reflects momentum. This is because from periods 12 - 26 (assuming the short window is 12 and long window 26) are just an EMA of the short window.

Creating an EMA with offset allows us to skip calculating the EMA during those periods, resulting in quicker accuracy of the macdhistogram.